### PR TITLE
Add tank equipment plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.flouz</groupId>
+    <artifactId>tankplugin</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>tankplugin</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/flouz/tank/EquipmentEffectManager.java
+++ b/src/main/java/com/flouz/tank/EquipmentEffectManager.java
@@ -1,0 +1,156 @@
+package com.flouz.tank;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitTask;
+
+public class EquipmentEffectManager implements Listener {
+
+    public static final String HELMET_NAME = "ТАНК ШЛЕМ - М";
+    public static final String CHESTPLATE_NAME = "ТАНК НАГРУДНИК - М";
+    public static final String LEGGINGS_NAME = "ТАНК ПОНОЖИ - М";
+    public static final String BOOTS_NAME = "ТАНК БОТИНКИ - М";
+    public static final String MACHETE_NAME = "Облученная Мачете - М";
+
+    private final TankPlugin plugin;
+    private BukkitTask repeatingTask;
+
+    public EquipmentEffectManager(TankPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start() {
+        if (repeatingTask != null) {
+            repeatingTask.cancel();
+        }
+        this.repeatingTask = Bukkit.getScheduler().runTaskTimer(plugin, this::updateAllPlayers, 20L, 20L);
+    }
+
+    public void stop() {
+        if (repeatingTask != null) {
+            repeatingTask.cancel();
+            repeatingTask = null;
+        }
+    }
+
+    private void updateAllPlayers() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            applyEquipmentEffects(player);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        applyEquipmentEffects(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        clearEffects(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (event.getPlayer() instanceof Player) {
+            Player player = (Player) event.getPlayer();
+            if (isWearingTankLeggings(player)) {
+                applyLeggingsEffect(player);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getPlayer() instanceof Player) {
+            Player player = (Player) event.getPlayer();
+            if (isWearingTankLeggings(player)) {
+                applyLeggingsEffect(player);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onItemHeldChange(PlayerItemHeldEvent event) {
+        int slot = event.getNewSlot();
+        if (slot == 0 || slot == 2) {
+            Player player = event.getPlayer();
+            if (isWearingTankLeggings(player)) {
+                applyLeggingsEffect(player);
+            }
+        }
+    }
+
+    private void applyEquipmentEffects(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        ItemStack helmet = inventory.getHelmet();
+        ItemStack chestplate = inventory.getChestplate();
+        ItemStack leggings = inventory.getLeggings();
+        ItemStack boots = inventory.getBoots();
+        ItemStack mainHand = inventory.getItemInMainHand();
+        ItemStack offHand = inventory.getItemInOffHand();
+
+        boolean helmetEquipped = isNamedItem(helmet, Material.DIAMOND_HELMET, HELMET_NAME);
+        boolean chestplateEquipped = isNamedItem(chestplate, Material.DIAMOND_CHESTPLATE, CHESTPLATE_NAME);
+        boolean leggingsEquipped = isNamedItem(leggings, Material.DIAMOND_LEGGINGS, LEGGINGS_NAME);
+        boolean bootsEquipped = isNamedItem(boots, Material.DIAMOND_BOOTS, BOOTS_NAME);
+        boolean macheteEquipped = isNamedItem(mainHand, Material.DIAMOND_SWORD, MACHETE_NAME)
+                || isNamedItem(offHand, Material.DIAMOND_SWORD, MACHETE_NAME);
+
+        handleEffect(player, PotionEffectType.NIGHT_VISION, helmetEquipped, 0);
+        handleEffect(player, PotionEffectType.REGENERATION, chestplateEquipped, 0);
+        handleEffect(player, PotionEffectType.SPEED, bootsEquipped, 0);
+        handleEffect(player, PotionEffectType.INCREASE_DAMAGE, macheteEquipped, 1);
+
+        if (leggingsEquipped) {
+            applyLeggingsEffect(player);
+        } else {
+            player.removePotionEffect(PotionEffectType.ABSORPTION);
+        }
+    }
+
+    private void clearEffects(Player player) {
+        player.removePotionEffect(PotionEffectType.NIGHT_VISION);
+        player.removePotionEffect(PotionEffectType.REGENERATION);
+        player.removePotionEffect(PotionEffectType.SPEED);
+        player.removePotionEffect(PotionEffectType.INCREASE_DAMAGE);
+        player.removePotionEffect(PotionEffectType.ABSORPTION);
+    }
+
+    private void applyLeggingsEffect(Player player) {
+        PotionEffect effect = new PotionEffect(PotionEffectType.ABSORPTION, Integer.MAX_VALUE, 0, false, false, true);
+        player.addPotionEffect(effect);
+    }
+
+    private void handleEffect(Player player, PotionEffectType type, boolean shouldHave, int amplifier) {
+        if (shouldHave) {
+            PotionEffect effect = new PotionEffect(type, Integer.MAX_VALUE, amplifier, false, false, true);
+            player.addPotionEffect(effect);
+        } else {
+            player.removePotionEffect(type);
+        }
+    }
+
+    private boolean isWearingTankLeggings(Player player) {
+        return isNamedItem(player.getInventory().getLeggings(), Material.DIAMOND_LEGGINGS, LEGGINGS_NAME);
+    }
+
+    public static boolean isNamedItem(ItemStack stack, Material material, String name) {
+        if (stack == null || stack.getType() != material || !stack.hasItemMeta()) {
+            return false;
+        }
+        String displayName = stack.getItemMeta().getDisplayName();
+        return displayName != null && displayName.equals(name);
+    }
+}

--- a/src/main/java/com/flouz/tank/FlouzCommand.java
+++ b/src/main/java/com/flouz/tank/FlouzCommand.java
@@ -1,0 +1,203 @@
+package com.flouz.tank;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class FlouzCommand implements CommandExecutor, TabCompleter {
+
+    private final TankPlugin plugin;
+
+    public FlouzCommand(TankPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Команду может использовать только игрок.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+
+        String first = args[0].toLowerCase();
+        switch (first) {
+            case "com":
+                return handleComCommand(player, args);
+            case "tank":
+                return handleTankCommand(player, args, 1);
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private boolean handleComCommand(Player player, String[] args) {
+        if (args.length < 2) {
+            sendUsage(player);
+            return true;
+        }
+
+        String second = args[1].toLowerCase();
+        switch (second) {
+            case "tank":
+                return handleTankCommand(player, args, 2);
+            case "luckydayz":
+                return handleLuckyDayzCommand(player, args);
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private boolean handleTankCommand(Player player, String[] args, int index) {
+        if (args.length <= index) {
+            sendUsage(player);
+            return true;
+        }
+
+        String target = args[index].toLowerCase();
+        switch (target) {
+            case "helmet":
+                giveItem(player, createArmor(Material.DIAMOND_HELMET, EquipmentEffectManager.HELMET_NAME));
+                player.sendMessage(ChatColor.GREEN + "Вы получили " + EquipmentEffectManager.HELMET_NAME + ChatColor.GREEN + ".");
+                return true;
+            case "bodyarmor":
+                giveItem(player, createArmor(Material.DIAMOND_CHESTPLATE, EquipmentEffectManager.CHESTPLATE_NAME));
+                player.sendMessage(ChatColor.GREEN + "Вы получили " + EquipmentEffectManager.CHESTPLATE_NAME + ChatColor.GREEN + ".");
+                return true;
+            case "lenghtarmor":
+                giveItem(player, createArmor(Material.DIAMOND_LEGGINGS, EquipmentEffectManager.LEGGINGS_NAME));
+                player.sendMessage(ChatColor.GREEN + "Вы получили " + EquipmentEffectManager.LEGGINGS_NAME + ChatColor.GREEN + ".");
+                return true;
+            case "boottarmor":
+                giveItem(player, createArmor(Material.DIAMOND_BOOTS, EquipmentEffectManager.BOOTS_NAME));
+                player.sendMessage(ChatColor.GREEN + "Вы получили " + EquipmentEffectManager.BOOTS_NAME + ChatColor.GREEN + ".");
+                return true;
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private boolean handleLuckyDayzCommand(Player player, String[] args) {
+        if (args.length < 3) {
+            sendUsage(player);
+            return true;
+        }
+
+        String third = args[2].toLowerCase();
+        switch (third) {
+            case "obla":
+                giveItem(player, createWeapon());
+                player.sendMessage(ChatColor.GREEN + "Вы получили " + EquipmentEffectManager.MACHETE_NAME + ChatColor.GREEN + ".");
+                return true;
+            case "apteka":
+                giveItem(player, createMedkit());
+                player.sendMessage(ChatColor.GREEN + "Вы получили аптечку.");
+                return true;
+            case "vert":
+                plugin.getHelicopterManager().spawnHelicopter(player);
+                return true;
+            default:
+                sendUsage(player);
+                return true;
+        }
+    }
+
+    private ItemStack createArmor(Material material, String displayName) {
+        ItemStack stack = new ItemStack(material);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(displayName);
+            meta.setUnbreakable(true);
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    private ItemStack createWeapon() {
+        ItemStack stack = new ItemStack(Material.DIAMOND_SWORD);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(EquipmentEffectManager.MACHETE_NAME);
+            meta.setUnbreakable(true);
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    private ItemStack createMedkit() {
+        ItemStack stack = new ItemStack(Material.GLOWSTONE_DUST);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(MedkitManager.MEDKIT_NAME);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    private void giveItem(Player player, ItemStack item) {
+        player.getInventory().addItem(item).values().forEach(leftover -> player.getWorld().dropItemNaturally(player.getLocation(), leftover));
+    }
+
+    private void sendUsage(Player player) {
+        player.sendMessage(ChatColor.RED + "Использование: /flouz1 com tank <helmet|bodyarmor|lenghtarmor|boottarmor>");
+        player.sendMessage(ChatColor.RED + "Использование: /flouz1 com luckydayz <obla|apteka|vert>");
+        player.sendMessage(ChatColor.RED + "Использование: /flouz1 tank <boottarmor>");
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return partial(Arrays.asList("com", "tank"), args[0]);
+        }
+        if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("com")) {
+                return partial(Arrays.asList("tank", "luckydayz"), args[1]);
+            } else if (args[0].equalsIgnoreCase("tank")) {
+                return partial(Collections.singletonList("boottarmor"), args[1]);
+            }
+        }
+        if (args.length == 3) {
+            if (args[0].equalsIgnoreCase("com") && args[1].equalsIgnoreCase("tank")) {
+                return partial(Arrays.asList("helmet", "bodyarmor", "lenghtarmor", "boottarmor"), args[2]);
+            }
+            if (args[0].equalsIgnoreCase("com") && args[1].equalsIgnoreCase("luckydayz")) {
+                return partial(Arrays.asList("obla", "apteka", "vert"), args[2]);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> partial(List<String> options, String token) {
+        String lower = token == null ? "" : token.toLowerCase();
+        List<String> result = new ArrayList<>();
+        for (String option : options) {
+            if (option.startsWith(lower)) {
+                result.add(option);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/flouz/tank/HelicopterManager.java
+++ b/src/main/java/com/flouz/tank/HelicopterManager.java
@@ -1,0 +1,210 @@
+package com.flouz.tank;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityMountEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class HelicopterManager implements Listener {
+
+    private final TankPlugin plugin;
+    private final Map<UUID, Helicopter> helicopters = new HashMap<>();
+    private final Map<UUID, Helicopter> standIndex = new HashMap<>();
+
+    public HelicopterManager(TankPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void spawnHelicopter(Player player) {
+        Helicopter existing = helicopters.remove(player.getUniqueId());
+        if (existing != null) {
+            unregister(existing);
+            existing.remove();
+            player.sendMessage(ChatColor.YELLOW + "Предыдущий вертолет был удален.");
+        }
+
+        Helicopter helicopter = new Helicopter(plugin, player);
+        helicopter.spawn();
+        register(helicopter);
+        player.sendMessage(ChatColor.GREEN + "Вертолет призван! Только вы можете в него сесть.");
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                helicopter.mountOwner();
+            }
+        }.runTask(plugin);
+    }
+
+    @EventHandler
+    public void onEntityMount(EntityMountEvent event) {
+        Entity mount = event.getMount();
+        if (!(mount instanceof ArmorStand)) {
+            return;
+        }
+
+        Helicopter helicopter = standIndex.get(mount.getUniqueId());
+        if (helicopter == null) {
+            return;
+        }
+
+        if (!(event.getEntity() instanceof Player)) {
+            event.setCancelled(true);
+            return;
+        }
+
+        Player player = (Player) event.getEntity();
+        if (!player.getUniqueId().equals(helicopter.getOwner().getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onStandDamage(EntityDamageEvent event) {
+        Entity entity = event.getEntity();
+        if (entity instanceof ArmorStand && standIndex.containsKey(entity.getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Helicopter helicopter = helicopters.remove(event.getPlayer().getUniqueId());
+        if (helicopter != null) {
+            unregister(helicopter);
+            helicopter.remove();
+        }
+    }
+
+    public void shutdown() {
+        for (Helicopter helicopter : new ArrayList<>(helicopters.values())) {
+            unregister(helicopter);
+            helicopter.remove();
+        }
+        helicopters.clear();
+        standIndex.clear();
+    }
+
+    private void register(Helicopter helicopter) {
+        helicopters.put(helicopter.getOwner().getUniqueId(), helicopter);
+        for (ArmorStand stand : helicopter.getParts()) {
+            standIndex.put(stand.getUniqueId(), helicopter);
+        }
+    }
+
+    private void unregister(Helicopter helicopter) {
+        for (ArmorStand stand : helicopter.getParts()) {
+            standIndex.remove(stand.getUniqueId());
+        }
+    }
+
+    private static class Helicopter {
+        private final TankPlugin plugin;
+        private final Player owner;
+        private final List<ArmorStand> parts = new ArrayList<>();
+        private ArmorStand seat;
+
+        private Helicopter(TankPlugin plugin, Player owner) {
+            this.plugin = plugin;
+            this.owner = owner;
+        }
+
+        public void spawn() {
+            Location base = owner.getLocation().clone();
+            base.setPitch(0f);
+
+            seat = spawnSeat(base);
+            parts.add(seat);
+
+            parts.add(spawnPart(base.clone().add(0, 0.4, 0), new ItemStack(Material.GRAY_CONCRETE), false));
+            parts.add(spawnPart(base.clone().add(0, 1.0, 0), new ItemStack(Material.IRON_TRAPDOOR), true));
+            parts.add(spawnPart(base.clone().add(0, 0.8, -0.7), new ItemStack(Material.LIGHT_GRAY_CONCRETE), false));
+            parts.add(spawnPart(base.clone().add(0.5, 0.6, 0), new ItemStack(Material.IRON_BARS), false));
+            parts.add(spawnPart(base.clone().add(-0.5, 0.6, 0), new ItemStack(Material.IRON_BARS), false));
+        }
+
+        private ArmorStand spawnSeat(Location location) {
+            ArmorStand stand = location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
+                armorStand.setVisible(false);
+                armorStand.setGravity(false);
+                armorStand.setMarker(false);
+                armorStand.setSmall(false);
+                armorStand.setBasePlate(false);
+                armorStand.setArms(false);
+                armorStand.setCollidable(false);
+                armorStand.setInvulnerable(true);
+                armorStand.setCustomNameVisible(false);
+            });
+            return stand;
+        }
+
+        private ArmorStand spawnPart(Location location, ItemStack helmet, boolean spin) {
+            ArmorStand stand = location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
+                armorStand.getEquipment().setHelmet(helmet);
+                armorStand.setMarker(true);
+                armorStand.setVisible(false);
+                armorStand.setGravity(false);
+                armorStand.setSmall(true);
+                armorStand.setBasePlate(false);
+                armorStand.setArms(false);
+                armorStand.setCollidable(false);
+                armorStand.setInvulnerable(true);
+            });
+
+            if (spin) {
+                new BukkitRunnable() {
+                    float yaw = 0f;
+
+                    @Override
+                    public void run() {
+                        if (!stand.isValid()) {
+                            cancel();
+                            return;
+                        }
+                        yaw += 15f;
+                        stand.setRotation(yaw, 0f);
+                    }
+                }.runTaskTimer(plugin, 0L, 2L);
+            }
+
+            return stand;
+        }
+
+        public Player getOwner() {
+            return owner;
+        }
+
+        public List<ArmorStand> getParts() {
+            return parts;
+        }
+
+        public void mountOwner() {
+            if (seat != null && seat.isValid() && owner.isOnline()) {
+                seat.addPassenger(owner);
+            }
+        }
+
+        public void remove() {
+            for (ArmorStand stand : parts) {
+                if (stand != null && stand.isValid()) {
+                    stand.remove();
+                }
+            }
+            parts.clear();
+        }
+    }
+}

--- a/src/main/java/com/flouz/tank/MedkitManager.java
+++ b/src/main/java/com/flouz/tank/MedkitManager.java
@@ -1,0 +1,145 @@
+package com.flouz.tank;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.ChatColor;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+public class MedkitManager implements Listener {
+
+    public static final String MEDKIT_NAME = ChatColor.WHITE + "" + ChatColor.BOLD + "Аптечка";
+    private static final String COUNTDOWN_PREFIX = ChatColor.WHITE + "" + ChatColor.BOLD + "Аптека отхилит вас через ";
+
+    private final TankPlugin plugin;
+    private final Map<UUID, BukkitTask> activeMedkits = new HashMap<>();
+
+    public MedkitManager(TankPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerUseMedkit(PlayerInteractEvent event) {
+        if (!event.getAction().name().contains("RIGHT_CLICK")) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        if (item == null || !isMedkit(item)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (activeMedkits.containsKey(player.getUniqueId())) {
+            player.sendMessage(ChatColor.RED + "Аптечка уже активирована.");
+            event.setCancelled(true);
+            return;
+        }
+
+        consumeItem(player, event.getHand());
+        event.setCancelled(true);
+        startCountdown(player);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        BukkitTask task = activeMedkits.remove(event.getPlayer().getUniqueId());
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    public void shutdown() {
+        for (BukkitTask task : activeMedkits.values()) {
+            task.cancel();
+        }
+        activeMedkits.clear();
+    }
+
+    private void startCountdown(Player player) {
+        BukkitRunnable runnable = new BukkitRunnable() {
+            private int seconds = 8;
+
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    cancelMedkit(player.getUniqueId());
+                    cancel();
+                    return;
+                }
+
+                player.sendMessage(COUNTDOWN_PREFIX + seconds);
+
+                if (seconds <= 0) {
+                    if (player.getAttribute(Attribute.GENERIC_MAX_HEALTH) != null) {
+                        player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
+                    } else {
+                        player.setHealth(player.getMaxHealth());
+                    }
+                    cancelMedkit(player.getUniqueId());
+                    cancel();
+                    return;
+                }
+
+                seconds--;
+            }
+        };
+
+        BukkitTask task = runnable.runTaskTimer(plugin, 0L, 20L);
+        activeMedkits.put(player.getUniqueId(), task);
+    }
+
+    private void cancelMedkit(UUID uuid) {
+        BukkitTask task = activeMedkits.remove(uuid);
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    private boolean isMedkit(ItemStack stack) {
+        if (stack == null || !stack.hasItemMeta()) {
+            return false;
+        }
+        String displayName = stack.getItemMeta().getDisplayName();
+        return displayName != null && displayName.equals(MEDKIT_NAME);
+    }
+
+    private void consumeItem(Player player, EquipmentSlot slot) {
+        if (slot == null) {
+            slot = EquipmentSlot.HAND;
+        }
+
+        ItemStack stack = slot == EquipmentSlot.HAND ? player.getInventory().getItemInMainHand()
+                : player.getInventory().getItemInOffHand();
+        if (stack == null) {
+            return;
+        }
+
+        int amount = stack.getAmount();
+        if (amount <= 1) {
+            stack.setAmount(0);
+            if (slot == EquipmentSlot.HAND) {
+                player.getInventory().setItemInMainHand(null);
+            } else {
+                player.getInventory().setItemInOffHand(null);
+            }
+        } else {
+            stack.setAmount(amount - 1);
+            if (slot == EquipmentSlot.HAND) {
+                player.getInventory().setItemInMainHand(stack);
+            } else {
+                player.getInventory().setItemInOffHand(stack);
+            }
+        }
+    }
+}

--- a/src/main/java/com/flouz/tank/TankPlugin.java
+++ b/src/main/java/com/flouz/tank/TankPlugin.java
@@ -1,0 +1,57 @@
+package com.flouz.tank;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class TankPlugin extends JavaPlugin {
+
+    private EquipmentEffectManager effectManager;
+    private MedkitManager medkitManager;
+    private HelicopterManager helicopterManager;
+
+    @Override
+    public void onEnable() {
+        this.effectManager = new EquipmentEffectManager(this);
+        this.medkitManager = new MedkitManager(this);
+        this.helicopterManager = new HelicopterManager(this);
+
+        Bukkit.getPluginManager().registerEvents(effectManager, this);
+        Bukkit.getPluginManager().registerEvents(medkitManager, this);
+        Bukkit.getPluginManager().registerEvents(helicopterManager, this);
+
+        effectManager.start();
+
+        PluginCommand command = getCommand("flouz1");
+        if (command != null) {
+            FlouzCommand executor = new FlouzCommand(this);
+            command.setExecutor(executor);
+            command.setTabCompleter(executor);
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        if (effectManager != null) {
+            effectManager.stop();
+        }
+        if (medkitManager != null) {
+            medkitManager.shutdown();
+        }
+        if (helicopterManager != null) {
+            helicopterManager.shutdown();
+        }
+    }
+
+    public EquipmentEffectManager getEffectManager() {
+        return effectManager;
+    }
+
+    public MedkitManager getMedkitManager() {
+        return medkitManager;
+    }
+
+    public HelicopterManager getHelicopterManager() {
+        return helicopterManager;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: TankPlugin
+main: com.flouz.tank.TankPlugin
+version: 1.0.0
+api-version: 1.16
+commands:
+  flouz1:
+    description: Tank equipment and utilities
+    usage: /flouz1


### PR DESCRIPTION
## Summary
- add a Maven-based Paper 1.16.5 plugin skeleton
- implement /flouz1 subcommands to give named tank gear, sword, medkit, and helicopter
- apply persistent potion effects, medkit countdown healing, and owner-only helicopter behavior

## Testing
- mvn -q package *(fails: unable to download maven-resources-plugin because repo.maven.apache.org returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e169b7ac588332b8e13f17c3cb2416